### PR TITLE
Fix material name conflicts

### DIFF
--- a/xenoblade_blender/export_root.py
+++ b/xenoblade_blender/export_root.py
@@ -64,17 +64,7 @@ def parse_int(name: str) -> Optional[int]:
 
     return value
 
-
-def extract_index(name: str) -> Tuple[Optional[int], str]:
-    name_parts = name.split(".", 1)
-
-    prefix = parse_int(name_parts[0])
-    name = name_parts[1] if len(name_parts) == 2 else name
-
-    return prefix, name
-
-
-def extract_image_name_index(name: str) -> Tuple[str, Optional[int]]:
+def extract_index_name(name: str) -> Tuple[str, Optional[int]]:
     # Extract image_name, index from model_name.index.image_name
     # Use >= to ignore any additional parts like file extension.
     name_parts = name.split(".")
@@ -836,7 +826,7 @@ def get_texture_assignments(mesh_data, material, image_textures):
 def image_index_to_replace(images, image_name: str) -> Optional[int]:
     # Find the original image to replace.
     # TODO: handle new images without an index?
-    image_name, image_index = extract_image_name_index(image_name)
+    image_name, image_index = extract_index_name(image_name)
     if image_index is None:
         for i, image in enumerate(images):
             if image.name == image_name:

--- a/xenoblade_blender/export_root.py
+++ b/xenoblade_blender/export_root.py
@@ -598,7 +598,7 @@ def apply_toon_gradient_row(mesh_data, material):
 
 
 def extract_mesh_index(mesh_name, original_meshes, material_index):
-    mesh_index, _ = extract_index(mesh_name)
+    _, mesh_index = extract_index_name(mesh_name)
     if mesh_index is None:
         for i, mesh in enumerate(original_meshes):
             if mesh.material_index == material_index:
@@ -618,7 +618,7 @@ def extract_toon_gradient_row(mesh_data) -> Optional[float]:
 def extract_material_name_info(materials, mesh_name, mesh_data):
     # Use names as a less accurate fallback for the original material.
     blender_material_name = mesh_data.materials[0].name
-    material_index, material_name = extract_index(blender_material_name)
+    material_name, material_index = extract_index_name(blender_material_name)
     is_new_material = True
     for i, material in enumerate(materials):
         if material.name == material_name:

--- a/xenoblade_blender/import_camdo.py
+++ b/xenoblade_blender/import_camdo.py
@@ -47,12 +47,6 @@ class ImportCamdo(bpy.types.Operator, ImportHelper):
         name="Image Folder",
         description="The folder for the imported images. Defaults to the file's parent folder if not set",
     )
-    
-    randomize_material_names: BoolProperty(
-        name="Randomize Material Names",
-        description="Toggle whether to randomize material names to avoid collisions",
-        default=False,
-    )
 
     def execute(self, context: bpy.types.Context):
         init_logging()
@@ -107,7 +101,6 @@ class ImportCamdo(bpy.types.Operator, ImportHelper):
             import_all_meshes=True,
             import_outlines=True,
             flip_uvs=False,
-            randomize_material_names=self.randomize_material_names,
         )
 
         end = time.time()

--- a/xenoblade_blender/import_camdo.py
+++ b/xenoblade_blender/import_camdo.py
@@ -47,6 +47,12 @@ class ImportCamdo(bpy.types.Operator, ImportHelper):
         name="Image Folder",
         description="The folder for the imported images. Defaults to the file's parent folder if not set",
     )
+    
+    randomize_material_names: BoolProperty(
+        name="Randomize Material Names",
+        description="Toggle whether to randomize material names to avoid collisions",
+        default=False,
+    )
 
     def execute(self, context: bpy.types.Context):
         init_logging()
@@ -101,6 +107,7 @@ class ImportCamdo(bpy.types.Operator, ImportHelper):
             import_all_meshes=True,
             import_outlines=True,
             flip_uvs=False,
+            randomize_material_names=self.randomize_material_names,
         )
 
         end = time.time()

--- a/xenoblade_blender/import_camdo.py
+++ b/xenoblade_blender/import_camdo.py
@@ -80,9 +80,10 @@ class ImportCamdo(bpy.types.Operator, ImportHelper):
         start = time.time()
 
         model_name = os.path.basename(path)
+        name = model_name.replace(".camdo", "")
         blender_images = import_images(
             root,
-            model_name.replace(".camdo", ""),
+            name,
             pack_images,
             image_folder,
             flip=False,
@@ -95,6 +96,7 @@ class ImportCamdo(bpy.types.Operator, ImportHelper):
         import_model_root(
             self,
             root,
+            name,
             blender_images,
             shader_images,
             armature,

--- a/xenoblade_blender/import_material.py
+++ b/xenoblade_blender/import_material.py
@@ -1,5 +1,6 @@
 from typing import Dict, Optional
 import bpy
+import uuid
 
 from . import xc3_model_py
 
@@ -11,7 +12,12 @@ def import_material(
     shader_images: Dict[str, bpy.types.Image],
     image_textures,
     samplers,
+    randomize_name: bool = False,
 ):
+    
+    if randomize_name:
+        name = f"{name}_{uuid.uuid4().hex[:8]}"  # Append random ID to the name
+    
     blender_material = bpy.data.materials.new(name)
 
     # Add some custom properties to make debugging easier.

--- a/xenoblade_blender/import_material.py
+++ b/xenoblade_blender/import_material.py
@@ -1,6 +1,5 @@
 from typing import Dict, Optional
 import bpy
-import uuid
 
 from . import xc3_model_py
 
@@ -12,12 +11,7 @@ def import_material(
     shader_images: Dict[str, bpy.types.Image],
     image_textures,
     samplers,
-    randomize_name: bool = False,
 ):
-    
-    if randomize_name:
-        name = f"{name}_{uuid.uuid4().hex[:8]}"  # Append random ID to the name
-    
     blender_material = bpy.data.materials.new(name)
 
     # Add some custom properties to make debugging easier.

--- a/xenoblade_blender/import_root.py
+++ b/xenoblade_blender/import_root.py
@@ -260,7 +260,6 @@ def import_model_root(
     import_all_meshes: bool,
     import_outlines: bool,
     flip_uvs: bool,
-    randomize_material_names: bool = False,
 ):
     base_lods = None
     if root.models.lod_data is not None:
@@ -283,7 +282,6 @@ def import_model_root(
                     shader_images,
                     root.image_textures,
                     root.models.samplers,
-                    randomize_name=randomize_material_names,
                 )
 
             if not import_all_meshes:

--- a/xenoblade_blender/import_root.py
+++ b/xenoblade_blender/import_root.py
@@ -254,6 +254,7 @@ def import_map_root(
 def import_model_root(
     operator,
     root,
+    model_name,
     blender_images: list[bpy.types.Image],
     shader_images: Dict[str, bpy.types.Image],
     root_obj,
@@ -271,7 +272,7 @@ def import_model_root(
             # Many materials are for meshes that won't be loaded.
             # Lazy load materials to improve import times.
             material = root.models.materials[mesh.material_index]
-            material_name = f"{mesh.material_index}.{material.name}"
+            material_name = f"{model_name}.{mesh.material_index}.{material.name}"
 
             blender_material = bpy.data.materials.get(material_name)
             if blender_material is None:

--- a/xenoblade_blender/import_root.py
+++ b/xenoblade_blender/import_root.py
@@ -260,6 +260,7 @@ def import_model_root(
     import_all_meshes: bool,
     import_outlines: bool,
     flip_uvs: bool,
+    randomize_material_names: bool = False,
 ):
     base_lods = None
     if root.models.lod_data is not None:
@@ -282,6 +283,7 @@ def import_model_root(
                     shader_images,
                     root.image_textures,
                     root.models.samplers,
+                    randomize_name=randomize_material_names,
                 )
 
             if not import_all_meshes:

--- a/xenoblade_blender/import_wimdo.py
+++ b/xenoblade_blender/import_wimdo.py
@@ -106,13 +106,15 @@ class ImportWimdo(bpy.types.Operator, ImportHelper):
         start = time.time()
 
         model_name = os.path.basename(path)
+        name = model_name.replace(".wimdo", "")
         blender_images = import_images(
-            root, model_name.replace(".wimdo", ""), pack_images, image_folder, flip=True
+            root, name, pack_images, image_folder, flip=True
         )
         armature = import_armature(self, context, root, model_name)
         import_model_root(
             self,
             root,
+            name,
             blender_images,
             shader_images,
             armature,

--- a/xenoblade_blender/import_wimdo.py
+++ b/xenoblade_blender/import_wimdo.py
@@ -60,12 +60,6 @@ class ImportWimdo(bpy.types.Operator, ImportHelper):
         description="Import data required to render and export outline meshes",
         default=True,
     )
-    
-    randomize_material_names: BoolProperty(
-        name="Randomize Material Names",
-        description="Toggle whether to randomize material names to avoid collisions",
-        default=False,
-    )
 
     def execute(self, context: bpy.types.Context):
         init_logging()
@@ -125,7 +119,6 @@ class ImportWimdo(bpy.types.Operator, ImportHelper):
             import_all_meshes,
             import_outlines,
             flip_uvs=True,
-            randomize_material_names=self.randomize_material_names,
         )
 
         # Store the path to make exporting easier later.

--- a/xenoblade_blender/import_wimdo.py
+++ b/xenoblade_blender/import_wimdo.py
@@ -60,6 +60,12 @@ class ImportWimdo(bpy.types.Operator, ImportHelper):
         description="Import data required to render and export outline meshes",
         default=True,
     )
+    
+    randomize_material_names: BoolProperty(
+        name="Randomize Material Names",
+        description="Toggle whether to randomize material names to avoid collisions",
+        default=False,
+    )
 
     def execute(self, context: bpy.types.Context):
         init_logging()
@@ -119,6 +125,7 @@ class ImportWimdo(bpy.types.Operator, ImportHelper):
             import_all_meshes,
             import_outlines,
             flip_uvs=True,
+            randomize_material_names=self.randomize_material_names,
         )
 
         # Store the path to make exporting easier later.


### PR DESCRIPTION
### Adds checkbox when importing wimdo & camdo.
Used mainly for importing many assets at once & needing unique materials.
This should solve the issue where multiple assets are imported & some materials share the same name, leading to meshes getting assigned incorrect materials.
Another option potentially is to use the armature or file name for material name suffix to differentiate.